### PR TITLE
It's "Tor" not "TOR" 

### DIFF
--- a/draft-hall-traffic-analysis.md
+++ b/draft-hall-traffic-analysis.md
@@ -154,7 +154,7 @@ Find out state of play regarding IPsec.
 
 ## Mixnets
 
-Talk about TOR (note also that TOR does some of the other things too)
+Talk about Tor (note also that Tor does some of the other things too)
 
 ## Moar Encryption
 


### PR DESCRIPTION
s/TOR/Tor/

and https://svn.torproject.org/svn/projects/design-paper/tor-design.html is a useful reference